### PR TITLE
Prevent data leakage for single-GPU training

### DIFF
--- a/pdearena/data/datamodule.py
+++ b/pdearena/data/datamodule.py
@@ -43,7 +43,7 @@ def collate_fn_stack(batch):
 class PDEDataModule(LightningDataModule):
     """Defines the standard dataloading process for PDE data.
 
-    Does not support generaliztion to different parameterizations or time.
+    Does not support generalization to different parameterizations or time.
     Consider using [pdearena.data.cond_datamodule.CondPDEDataModule][] for that.
 
     Args:

--- a/pdearena/models/pdemodel.py
+++ b/pdearena/models/pdemodel.py
@@ -124,8 +124,8 @@ class PDEModel(LightningModule):
             self.log("train/vector_loss", vector_loss)
             return {
                 "loss": loss,
-                "scalar_loss": scalar_loss,
-                "vector_loss": vector_loss,
+                "scalar_loss": scalar_loss.detach(),
+                "vector_loss": vector_loss.detach(),
             }
         elif self._mode == "3D":
             raise NotImplementedError(f"{self._mode}")


### PR DESCRIPTION
Hi, 

thanks for creating this great resource on Neural PDE Surrogates! 

When training a UNet on the Navier Stokes dataset with a single GPU, I noticed that the GPU memory was gradually increasing over the first training epoch. Starting at 7.6GB (batch size 8), it reached >23GB at iteration 4800, causing an out-of-memory error on a RTX3090 (increase of ~2MB per step). However, when training with much smaller epoch sizes (e.g. 100 batches), this error did not occur, even after 50 epochs. 

After closer inspection of the `PDEModel` class, I noticed that the step outputs `scalar_loss` and `vector_loss` are creating additional computation graphs independent of the `loss`. I suspect that these computation graphs (up the prediction tensor) are not cleared in the single-GPU training, and simply detaching the two losses before returning fixed the data leakage (the memory stays at 7.6GB). Given that the code was likely tested with ddp training strategy, I suspect that this is a difference internally in PyTorch Lightning, but I assume detaching here should not cause any issue anyway. 

This PR adds the `detach` statement for the extra outputs during training. 
To reproduce the error, I have used the following training command:
```
python scripts/train.py -c configs/navierstokes2d.yaml \
    --data.data_dir=/mnt/data/NavierStokes2D_smoke \
    --trainer.devices=1 \
    --trainer.max_epochs=50 \
    --data.batch_size=8 \
    --data.time_gap=0 --data.time_history=4 --data.time_future=1 \
    --model.name=Unetmod-64 \
    --model.lr=2e-4 \
    --optimizer=AdamW --optimizer.lr=2e-4 --optimizer.weight_decay=1e-5 \
    --lr_scheduler=LinearWarmupCosineAnnealingLR \
    --lr_scheduler.warmup_epochs=5 \
    --lr_scheduler.max_epochs=50 --lr_scheduler.eta_min=1e-7
```