### PR TITLE
Data generation documentation: correcting command line overwrite of sample rate

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -13,15 +13,15 @@
 export seed=42;
 
 python scripts/generate_data.py base=pdedatagen/configs/navierstokes2dsmoke.yaml \
-    experiment=smoke mode=train samples=256 seed=$seed pdeconfig.sample_rate=4 \
+    experiment=smoke mode=train samples=256 seed=$seed pdeconfig.init_args.sample_rate=4 \
     dirname=/mnt/data/navierstokes;
 
 python scripts/generate_data.py base=pdedatagen/configs/navierstokes2dsmoke.yaml \
-    experiment=smoke mode=valid samples=32 seed=$seed pdeconfig.sample_rate=4 \
+    experiment=smoke mode=valid samples=32 seed=$seed pdeconfig.init_args.sample_rate=4 \
     dirname=/mnt/data/navierstokes;
 
 python scripts/generate_data.py base=pdedatagen/configs/navierstokes2dsmoke.yaml \
-    experiment=smoke mode=test samples=32 seed=$seed pdeconfig.sample_rate=4 \
+    experiment=smoke mode=test samples=32 seed=$seed pdeconfig.init_args.sample_rate=4 \
     dirname=/mnt/data/navierstokes;
 ```
 


### PR DESCRIPTION
Hi,

Thanks again for the resource! When running the data generation of the unconditional Navier-Stokes dataset, I noticed that the sample rate was 1, although the command in the documentation suggested it to be 4 (`pdeconfig.sample_rate=4`). This seems to be because the sample rate is defined in `pdeconfig.init_args.sample_rate`, and changing the statement to `pdeconfig.init_args.sample_rate=4` generates the data with the expected sample rate of 4. This pull request updates the documentation correspondingly.